### PR TITLE
Add Deus to Agentic Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Free, open-source frameworks for building AI agents and multi-agent systems.
 | [AgentVerse (OpenBMB)](https://github.com/OpenBMB/AgentVerse) | Framework for building and evaluating multi-agent environments. Easily configure agent teams and measure collaborative performance. |
 | [Qwen-Agent (Alibaba)](https://github.com/QwenLM/Qwen-Agent) | Agent framework tightly integrated with the Qwen model family. Optimized for function calling, code execution, RAG, and tool use with Qwen models. |
 | [AGiXT](https://github.com/Josh-XT/AGiXT) | Extensible modular AI agent automation platform. Plugin system for swapping LLMs, memory backends, and tools. Highly customizable agent workflows. |
+| [Deus](https://github.com/sliamh11/Deus) | Self-hosted personal AI assistant framework built around long-term memory, a self-improving evolution loop, and multi-agent orchestration. Backend-neutral (Claude Code, OpenAI/Codex, or fully local Ollama models), container-isolated agents, multi-channel (WhatsApp, Telegram, Slack, Discord, Gmail). MIT. |
 
 ---
 


### PR DESCRIPTION
## What

Adds **[Deus](https://github.com/sliamh11/Deus)** to the 🧩 Agentic Frameworks section.

Deus is an open-source (MIT) self-hosted personal AI assistant framework built around three differentiators:
- **Long-term memory** — a semantic vault the agent reads/writes across sessions
- **Self-improving evolution loop** — reflexion-style learning from its own runs
- **Multi-agent orchestration** — isolated, container-sandboxed agents

It's **backend-neutral** (Claude Code, OpenAI/Codex, or fully local **Ollama** models), so it runs end-to-end without paid APIs, and it's multi-channel (WhatsApp, Telegram, Slack, Discord, Gmail).

## Inclusion checklist

- ✅ Genuinely free to use — open-source, self-hosted, runs on local Ollama models (no paid API or credit card required)
- ✅ Real, working project — actively developed
- ✅ License noted — MIT
- ✅ GitHub link — https://github.com/sliamh11/Deus
- ✅ Matches the existing table format in the Agentic Frameworks section

Thanks for maintaining this list!