### PR TITLE
Add stillworks to Resources & Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Free courses, books, and tutorials for learning AI and LLMs.
 - [OpenRouter Models](https://openrouter.ai/models) — Browse models available via API with pricing and free tiers.
 - [Ollama Library](https://ollama.com/library) — Browse models available for one-command local setup.
 - [cheahjs/free-llm-api-resources](https://github.com/cheahjs/free-llm-api-resources) — Community-maintained list of free LLM API resources.
+- [stillworks](https://stillworks.supercapybara.com/) — Directories list. We check. Live-probed status of free LLM API endpoints, verified by real chat completions instead of provider docs. [GitHub](https://github.com/bon5co/stillworks)
 
 ---
 


### PR DESCRIPTION
Adds one entry to **Resources & Leaderboards**, next to `cheahjs/free-llm-api-resources`.

```
- [stillworks](https://stillworks.supercapybara.com/) — Directories list. We check. Live-probed status of free LLM API endpoints, verified by real chat completions instead of provider docs. [GitHub](https://github.com/bon5co/stillworks)
```

**What it is:** a registry of LLM endpoints where every row was produced by a real chat completion sent on a
schedule, not by reading a provider's documentation. Failures are published next to the successes. 19 endpoints
currently answer with no `Authorization` header at all; another 46 are free-tier-with-key, kept in the same
table but labelled. `GET /api/llm/up` returns them ranked, so `models[0]` is the pick and the rest are
fallbacks. Capability flags (`tools`, `json_schema`, `json_object`, `vision`) are listed as `proved` only when
a real call demonstrated them; provider claims that could not be reproduced sit in `claimed_unproved`.

**Why it belongs in this section:** it answers the question the rest of the section leaves open — of the free
endpoints listed elsewhere, which ones are answering right now.

**What it does not claim:** keyless quotas are commonly per-IP, so an endpoint verified from the service's
address can still refuse yours. Rows probed with the project's own free-tier key prove only that the endpoint
answered that account. It is a young project with a small number of endpoints. All of this is stated on the
page and in the API response rather than buried.

MIT licensed, source at https://github.com/bon5co/stillworks

Disclosure: I work on stillworks — this is a self-submission, not a third-party recommendation. Happy to trim
or reword the line to match the section.
