### PR TITLE
Add Atomic Agent to AI Coding Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Free tools that integrate AI into your development workflow.
 - [CodeWhale](https://github.com/Hmbown/CodeWhale) — **2026.** Terminal coding agent with 40K+ stars. 30+ providers, local models via Ollama/vLLM. TUI, headless mode, web UI. MIT license.
 - [nanobot (HKUDS)](https://github.com/HKUDS/nanobot) — **2026.** Open-source, ultra-lightweight personal AI agent with WebUI, chat channels, MCP, memory, and scheduling. 46K★. MIT.
 - [MiMoCode (Xiaomi)](https://github.com/XiaomiMiMo/MiMo-Code) — **Jun 2026.** Terminal-native coding agent with persistent memory, subagent orchestration, and goal-driven autonomous loops. 12.4K★. MIT.
+- [Atomic Agent](https://atomicagent.io/) — **2026.** Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. No account or API key required. 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, five-layer local memory. macOS, Linux, Windows. 2K★. MIT. [GitHub](https://github.com/AtomicBot-ai/atomic-agent)
 
 ---
 


### PR DESCRIPTION
#### Add Atomic Agent

> Hi! I'm the CPO of Atomic Agent. Thanks for this great list, it's one of the most useful roundups of genuinely free AI tooling out there, and our team would be thrilled if you added us.

Atomic Agent is a local-first CLI and TUI coding agent. It runs open-weight models entirely on your machine through a llama.cpp fork, so there is no account and no API key required to install and run it. The TUI is built on React and ink.

Checked against the inclusion requirements in CONTRIBUTING.md:

- **Genuinely free**: MIT license, no paid tier, no credit card, no "free trial". Install with `curl -fsSL https://atomicagent.io/install | sh`
- **Real, working project**: ~2K★, active development (pushed this week), not archived
- **Permissive license**: MIT, matching the "prefer permissively licensed" guidance
- **Section fit**: placed in **AI Coding Assistants** next to Aider, Goose, Qwen Code, and CodeWhale, which are the closest neighbours: end-user terminal coding agents rather than libraries for building agents

What it does: 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, a five-layer local memory system, and cross-platform builds for macOS, Linux, and Windows.

One honest note on age: the repo is about 4 months old. It is active and maintained by the AtomicBot-ai organization, which ships several established projects, so it is not a drive-by release.

More links, in case they're useful to you (only the site and GitHub are in the row itself, following the tool format):

- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- GitHub: https://github.com/AtomicBot-ai/atomic-agent
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

Happy to adjust the wording, trim the description, or move the entry to a different section if you'd prefer it elsewhere. Thanks for maintaining this!
