### PR TITLE
Add AISO Tools MCP to MCP Servers & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Model Context Protocol (MCP) servers that connect AI assistants to external tool
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) — **31.7K★.** Official GitHub MCP server by GitHub. Repository management, issue/PR automation, CI/CD intelligence, code analysis. OAuth or PAT auth. MIT license.
 - [GitMCP](https://github.com/idosal/git-mcp) — **8.2K★.** Free, open-source, remote MCP server for any GitHub project. Zero-setup documentation and code access for AI assistants. Apache 2.0.
 - [MCP Reference Servers (Anthropic)](https://github.com/modelcontextprotocol/servers) — **88.9K★.** Official reference implementations: Filesystem, Git, Fetch, Memory, Time, Sequential Thinking. Apache 2.0 / MIT.
+- [AISO Tools MCP](https://aisotools.com/mcp) — Hosted remote MCP server (Streamable HTTP) exposing a searchable catalog of 1,719 AI tools. No API key, no account, no rate-limit tier — connect the URL and call `search_ai_tools`. Listed in the official MCP registry as `io.github.shibley/aisotools`. [server.json](https://github.com/shibley/aisotools-mcp-server)
 
 ---
 


### PR DESCRIPTION
One entry in **🔧 MCP Servers & Tools**, after the Anthropic reference-servers row.

```
- [AISO Tools MCP](https://aisotools.com/mcp) — Hosted remote MCP server (Streamable HTTP)
  exposing a searchable catalog of 1,719 AI tools. No API key, no account, no rate-limit
  tier — connect the URL and call `search_ai_tools`. Listed in the official MCP registry
  as `io.github.shibley/aisotools`. [server.json](https://github.com/shibley/aisotools-mcp-server)
```

### Against your inclusion rules

**"Must be genuinely free to use (not free trial with credit card required)."** There is no auth on the endpoint at all — no key, no signup, no metered tier. Reproduce with a bare `curl`:

```
$ curl -s -X POST https://aisotools.com/api/mcp \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}'

{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",
 "capabilities":{"tools":{"listChanged":false}},
 "serverInfo":{"name":"aisotools","version":"0.1.0"},
 "instructions":"Read-only access to the AISOTools directory of 1719 AI tools. ..."}}
```

`tools/list` returns 5 read-only tools: `search_ai_tools`, `get_ai_tool`, `list_ai_tool_categories`, `compare_ai_tools`, `get_ai_tool_alternatives`.

**"Must be a real, working project or service."** Independently verifiable — it is `active` in `registry.modelcontextprotocol.io` under `io.github.shibley/aisotools`, published via GitHub OIDC.

**Format.** Your CONTRIBUTING's tool format is `[ToolName](https://example.com/) - Description. [GitHub](...)`, so the primary link is the service and the repo link is secondary. I used an em-dash to match the rows already in that section rather than the hyphen in CONTRIBUTING — say the word and I'll switch it.

### Two things I'd rather you hear from me than find later

1. **No star count.** The other three rows in that section carry one; this is a hosted service, so the linked repo is registry metadata (`server.json` + LICENSE), not the implementation. I left the `**N★.**` prefix off rather than quote a meaningless 3.
2. **I run aisotools.com.** Self-submission — reject on that basis if it's your policy; I couldn't find one stated either way in CONTRIBUTING.

The `1,719` figure is read off the live `initialize` response above, not off our marketing page.