### PR TITLE
Add Agent QA MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Model Context Protocol (MCP) servers that connect AI assistants to external tool
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) — **31.7K★.** Official GitHub MCP server by GitHub. Repository management, issue/PR automation, CI/CD intelligence, code analysis. OAuth or PAT auth. MIT license.
 - [GitMCP](https://github.com/idosal/git-mcp) — **8.2K★.** Free, open-source, remote MCP server for any GitHub project. Zero-setup documentation and code access for AI assistants. Apache 2.0.
 - [MCP Reference Servers (Anthropic)](https://github.com/modelcontextprotocol/servers) — **88.9K★.** Official reference implementations: Filesystem, Git, Fetch, Memory, Time, Sequential Thinking. Apache 2.0 / MIT.
+- [Agent QA](https://github.com/vostride/agent-qa) - Free, source-available MCP server and CLI for natural-language web/mobile tests with persistent test memory. FSL-1.1-ALv2; Apache-2.0 after two years.
 
 ---
 


### PR DESCRIPTION
## Summary

Add Agent QA to **MCP Servers & Tools**. Its CLI exposes an MCP server through `agent-qa mcp`, allowing AI clients to author and run natural-language web/mobile tests with persistent test memory.

## Free-use and license notes

- The Agent QA package and MCP server do not require an Agent QA subscription or license fee.
- It supports local models as well as OpenAI-, Anthropic-, and Gemini-compatible providers; a selected hosted model may have its own provider charges.
- The code is source-available under FSL-1.1-ALv2 and converts to Apache-2.0 after two years. The list entry states this explicitly.

## Verification

- Confirmed the published CLI exposes the `mcp` command.
- `git diff --check` passes.
- `awesome-lint` reports no finding on the added line. The repository-wide baseline remains 294 errors and 1 warning.

Disclosure: I am affiliated with Agent QA and Vostride.
