### PR TITLE
Add China AI Arbitrage to Resources & Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ Free courses, books, and tutorials for learning AI and LLMs.
 - [Hugging Face Models](https://huggingface.co/models) — Search 1M+ models. Filter by license, task, framework.
 - [OpenRouter Models](https://openrouter.ai/models) — Browse models available via API with pricing and free tiers.
 - [Ollama Library](https://ollama.com/library) — Browse models available for one-command local setup.
+- [China AI Arbitrage](https://www.china-ai-arbitrage.xyz/) — Tracker for free AI token offers and cheap third-party API relays with real quota benchmarks. Side-by-side pricing comparison across 20+ AI APIs, plus in-depth analysis blogs on DeepSeek, Kimi, and GLM.
 
 ---
 


### PR DESCRIPTION
Adds [China AI Arbitrage](https://www.china-ai-arbitrage.xyz/) to the **Resources & Leaderboards** section.

**What it is:** a free tracker for AI token offers and third-party API relays with real quota benchmarks — side-by-side pricing comparison across 20+ AI APIs, plus in-depth analysis blogs on DeepSeek, Kimi, and GLM.

**Why this section:** the list already features independent benchmark/comparison resources there (Artificial Analysis, LMSYS Chatbot Arena). China AI Arbitrage fills the pricing-benchmark niche for free tokens and cheap relays, which no existing entry covers.

Disclosure: I operate this site, so this is a self-submission. It is genuinely free to use — no paid tier is required to access the benchmarks or pricing data.