### PR TITLE
Add OrcaRouter to Free API Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Providers offering free tiers to access models via API — no local hardware req
 - [Agnes AI](https://platform.agnes-ai.com/) — **5 free models** — Free tier with Agnes 1.5/2.0 Flash and image models. 256K context, 30 RPM. Registration only, no credit card.
 - [Glhf.chat](https://glhf.chat/) — **⚠️ Currently unreachable (HTTP 522) at check time.** Previously offered a free OpenAI-compatible API; verify availability before relying on it.
 - [Nscale](https://console.nscale.com/) — **2 free models** — Free tier (registration only) with Llama 3.3 70B and DeepSeek-R1-Distill-70B. 128K context. OpenAI-compatible.
-- [OrcaRouter](https://www.orcarouter.ai/offers) — **4 free models** — DeepSeek V4 Pro, DeepSeek V4 Flash, Qwen3.8 27B, and Tencent Hy3 at $0 per token, plus an `orcarouter/free` alias that auto-routes across the free lineup. OpenAI-, Anthropic-, and Gemini-compatible endpoints. No credit card and no trial expiry; rotating voucher, student, and hackathon credit offers are listed on the same page.
+- [OrcaRouter](https://www.orcarouter.ai/offers) — **4 free models** — DeepSeek V4 Pro, DeepSeek V4 Flash, Qwen3.8 27B, and Tencent Hy3 at $0 per token, plus an `orcarouter/free` alias that auto-routes across the free lineup. OpenAI-, Anthropic-, and Gemini-compatible endpoints. No credit card and no trial expiry. The same page also gives away free vouchers for frontier models — e.g. $10 (~5M tokens) on Grok 4.5 — plus student programs and partner-hackathon credit, browsable without an account; each card shows its own terms and flags any card requirement.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Providers offering free tiers to access models via API — no local hardware req
 - [Agnes AI](https://platform.agnes-ai.com/) — **5 free models** — Free tier with Agnes 1.5/2.0 Flash and image models. 256K context, 30 RPM. Registration only, no credit card.
 - [Glhf.chat](https://glhf.chat/) — **⚠️ Currently unreachable (HTTP 522) at check time.** Previously offered a free OpenAI-compatible API; verify availability before relying on it.
 - [Nscale](https://console.nscale.com/) — **2 free models** — Free tier (registration only) with Llama 3.3 70B and DeepSeek-R1-Distill-70B. 128K context. OpenAI-compatible.
+- [OrcaRouter](https://www.orcarouter.ai/offers) — **4 free models** — DeepSeek V4 Pro, DeepSeek V4 Flash, Qwen3.8 27B, and Tencent Hy3 at $0 per token, plus an `orcarouter/free` alias that auto-routes across the free lineup. OpenAI-, Anthropic-, and Gemini-compatible endpoints. No credit card and no trial expiry; rotating voucher, student, and hackathon credit offers are listed on the same page.
 
 ---
 


### PR DESCRIPTION
Adds **OrcaRouter** to the 🔌 Free API Providers section.

### Why it qualifies

Per `CONTRIBUTING.md`, the entry must be *"genuinely free to use (not 'free trial with credit card required')"*. OrcaRouter keeps a permanent set of models priced at $0 per token:

| Model | ID |
|---|---|
| DeepSeek V4 Pro (Free) | `deepseek/deepseek-v4-pro-free` |
| DeepSeek V4 Flash (Free) | `deepseek/deepseek-v4-flash-free` |
| Qwen3.8 27B (free) | `qwen/qwen3.8-27b-free` |
| Tencent Hy3 (Free) | `tencent/hy3-free` |

These are not trial credits — no credit card is required and there is no expiry clock. There is also an `orcarouter/free` alias that auto-routes across the free lineup, similar to the existing BazaarLink (`auto:free`) and ZeroLimitAI (`model: "auto"`) entries.

### How the numbers were verified

The `4 free models` count is not marketing copy — it comes from the public pricing endpoint, filtered to models with both `model_ratio == 0` and `model_price == 0` that are enabled for the `default` (free) group:

```bash
curl -s https://www.orcarouter.ai/api/pricing \
  | python3 -c "import json,sys; d=json.load(sys.stdin)['data']; \
print([m['model_name'] for m in d if m['model_ratio']==0 and m['model_price']==0])"
```

Endpoint compatibility (`openai`, `anthropic`, `gemini`) is from `supported_endpoint_types` in `https://api.orcarouter.ai/v1/models`.

### Notes on the guidelines

- **No redirect chains** — linked `https://www.orcarouter.ai/offers`, which returns a direct `200`. The bare-domain form (`orcarouter.ai/offers`) `301`s to `www`, so I avoided it.
- **Section choice** — placed under *Free API Providers* rather than *Free API Routers*, since that section is described as *"open-source tools that route requests"* and its entries all carry GitHub links. OrcaRouter is a hosted service, so it follows the OpenRouter precedent already in Free API Providers.
- I left the header badge counts (`Models-49` / `Tools-245`) untouched, assuming you regenerate those — happy to bump them if you'd prefer.

### Disclosure

I'm affiliated with OrcaRouter. Only the free, no-card tier is described above; the two credit promos currently listed on the offers page are both fully claimed (`remaining: 0`), so I deliberately did not present them as available — the entry describes them only as a rotating feature. Happy to adjust the wording or drop the entry if that doesn't meet the bar for the list.