### PR TITLE
Add OrcaRouter to Free API Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Providers offering free tiers to access models via API — no local hardware req
 - [Agnes AI](https://platform.agnes-ai.com/) — **5 free models** — Free tier with Agnes 1.5/2.0 Flash and image models. 256K context, 30 RPM. Registration only, no credit card.
 - [Glhf.chat](https://glhf.chat/) — **⚠️ Currently unreachable (HTTP 522) at check time.** Previously offered a free OpenAI-compatible API; verify availability before relying on it.
 - [Nscale](https://console.nscale.com/) — **2 free models** — Free tier (registration only) with Llama 3.3 70B and DeepSeek-R1-Distill-70B. 128K context. OpenAI-compatible.
+- [OrcaRouter](https://www.orcarouter.ai/offers) — **4 free models** — DeepSeek V4 Pro, DeepSeek V4 Flash, Qwen3.8 27B, and Tencent Hy3 at $0 per token, plus an `orcarouter/free` alias that auto-routes across the free lineup. OpenAI-, Anthropic-, and Gemini-compatible endpoints. No credit card and no trial expiry. The same page also gives away free vouchers for frontier models — e.g. $10 (~5M tokens) on Grok 4.5 — plus student programs and partner-hackathon credit, browsable without an account; each card shows its own terms and flags any card requirement.
 
 ---
 


### PR DESCRIPTION
Adds **OrcaRouter** to the 🔌 Free API Providers section. One line, one commit.

```markdown
- [OrcaRouter](https://www.orcarouter.ai/offers) — **4 free models** — DeepSeek V4 Pro, DeepSeek V4 Flash, Qwen3.8 27B, and Tencent Hy3 at $0 per token, plus an `orcarouter/free` alias that auto-routes across the free lineup. OpenAI-, Anthropic-, and Gemini-compatible endpoints. No credit card and no trial expiry. The same page also gives away free vouchers for frontier models — e.g. $10 (~5M tokens) on Grok 4.5 — plus student programs and partner-hackathon credit, browsable without an account; each card shows its own terms and flags any card requirement.
```

### Why it qualifies

`CONTRIBUTING.md` requires entries to be *"genuinely free to use (not 'free trial with credit card required')"*. OrcaRouter keeps a permanent lineup priced at $0 per token — not trial credit, no card, no expiry clock:

| Model | ID |
|---|---|
| DeepSeek V4 Pro (Free) | `deepseek/deepseek-v4-pro-free` |
| DeepSeek V4 Flash (Free) | `deepseek/deepseek-v4-flash-free` |
| Qwen3.8 27B (free) | `qwen/qwen3.8-27b-free` |
| Tencent Hy3 (Free) | `tencent/hy3-free` |

There is also an `orcarouter/free` alias that auto-routes across the free lineup, mirroring the existing BazaarLink (`auto:free`) and ZeroLimitAI (`model: "auto"`) entries.

### How the count was verified

The `4 free models` figure is derived from the public pricing endpoint, not from marketing copy — models where both `model_ratio` and `model_price` are `0` and the free (`default`) group is enabled:

```bash
curl -s https://www.orcarouter.ai/api/pricing \
  | python3 -c "import json,sys; d=json.load(sys.stdin)['data']; \
print([m['model_name'] for m in d if m['model_ratio']==0 and m['model_price']==0])"
```

Endpoint compatibility (`openai`, `anthropic`, `gemini`) comes from `supported_endpoint_types` in `https://api.orcarouter.ai/v1/models`.

### The voucher clause, and its caveat

The page also runs credit drops — vouchers, student programs, partner hackathons — scoped to frontier models. The `$10 (~5M tokens)` example matches `quota: 5000000` on the `grok/grok-4.5` offer in `https://www.orcarouter.ai/api/offers`.

Being upfront: **that Grok 4.5 voucher is currently fully claimed** (`140/140`, `sold_out: true`) and carries `require_card: true`, and the Opus 5 hackathon has passed its `enroll_by`. Both are visible on the card in the screenshot below — page as of today:

![OrcaRouter offers page](https://raw.githubusercontent.com/akf66/awesome-free-models/pr-assets/orcarouter-offers-en.png)

So the clause is written to describe the drop mechanism, with the card-requirement caveat inline — it should not be read as "$10 free credit available right now." The part of the entry that actually meets your inclusion bar is the four `*-free` models, which stand independently of any promo. **If you'd prefer the voucher sentence trimmed or dropped, say so and I'll push that** — the entry works fine without it.

### Notes on the guidelines

- **No redirect chains** — linked `https://www.orcarouter.ai/offers`, a direct `200`. The bare-domain form `301`s to `www`, so I avoided it.
- **Section choice** — placed under *Free API Providers* rather than *Free API Routers*, since the latter is described as *"open-source tools that route requests"* and all its entries carry GitHub links. OrcaRouter is a hosted service, so it follows the OpenRouter precedent already in this section.
- **Badges untouched** — left `Models-49` / `Tools-245` alone assuming you regenerate them; happy to bump if you'd rather.

### Disclosure

I'm affiliated with OrcaRouter. Only the free, no-card tier is presented as the basis for inclusion, and the promo caveats above are stated deliberately rather than glossed. Happy to adjust wording or drop the entry if it doesn't meet the bar for the list.