### PR TITLE
docs: add SandBase CLI to free API routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Open-source tools that route requests across multiple AI providers — unified A
 - [OmniRoute](https://omniroute.online/) — Full-stack AI gateway with 250+ providers, 90+ free. TypeScript, runs on Web/Desktop/Android. Prompt compression, 3-level proxy for geo restrictions. [GitHub](https://github.com/diegosouzapw/OmniRoute)
 - [LiteLLM](https://litellm.ai/) — Python-based proxy unifying 100+ LLMs behind a single API. Spend tracking, virtual keys, production-ready. MIT license. [GitHub](https://github.com/BerriAI/litellm)
 - [Portkey AI Gateway](https://portkey.ai/) — Production guardrails and routing for AI apps. Hybrid open-source (community) and managed (enterprise) tiers. [GitHub](https://github.com/Portkey-AI/gateway)
+- [SandBase CLI](https://github.com/sandbaseai/cli) — Apache-2.0 CLI/MCP bridge for coding agents, routing requests across 2,000+ AI models through one OpenAI-compatible endpoint. Supports Claude Code, Codex CLI, Cursor, Gemini CLI, Windsurf, and other clients.
 
 ---
 


### PR DESCRIPTION
Adds SandBase CLI to the Free API Routers section.

- Official repository: https://github.com/sandbaseai/cli
- Apache-2.0 licensed open-source CLI/MCP bridge
- Routes coding-agent requests across 2,000+ AI models via an OpenAI-compatible endpoint

This is a documentation-only entry; please adjust or remove any wording that does not fit the list's criteria. Self-submitted by the project maintainer.