### PR TITLE
Add Free AI API Telegram channel to Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Free courses, books, and tutorials for learning AI and LLMs.
 - [Hugging Face Forums](https://discuss.huggingface.co/) — Discussions on models, datasets, and Spaces.
 - [r/MachineLearning](https://reddit.com/r/MachineLearning) — General ML/AI research and news.
 - [Discord: AI Agents](https://discord.gg/ai-agents) — Community for AI agent development and agentic frameworks.
+- [Free AI API (Telegram)](https://t.me/free_ai_api_ru) — Daily posts on free tiers that need no card: limits, rate limits, and whether the endpoint is OpenAI-compatible. Each offer is checked against the provider's own page before posting.
 
 ---
 


### PR DESCRIPTION
Adds one Telegram community to the Communities section.

Daily posts about free tiers that work without a card: what the limit is, how many requests per day, and whether the endpoint is OpenAI-compatible.

Every offer is verified against the provider's own pricing or docs page before it goes out; entries that turn out to be trials-with-card or dead endpoints get dropped rather than posted. No referral links.

Happy to adjust the wording or drop it if it does not fit.