### PR TITLE
Add Free LLM API Deals to Resources & Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Free courses, books, and tutorials for learning AI and LLMs.
 - [Artificial Analysis](https://artificialanalysis.ai/) — Independent benchmarks for speed, pricing, and quality across providers.
 - [Hugging Face Models](https://huggingface.co/models) — Search 1M+ models. Filter by license, task, framework.
 - [OpenRouter Models](https://openrouter.ai/models) — Browse models available via API with pricing and free tiers.
+- [Free LLM API Deals](https://github.com/RomeroYang/free-llm-api-deals) — Machine-readable dataset of free tiers, trial credits, and price cuts across LLM API providers. Every entry carries a source URL and a verified date; refreshed daily.
 - [Ollama Library](https://ollama.com/library) — Browse models available for one-command local setup.
 
 ---


### PR DESCRIPTION
Adds one line to **Resources & Leaderboards**, next to OpenRouter Models — it answers the same "what is free right now" question rather than being a benchmark. (That section is not in CONTRIBUTING.md's section list, so let me know if you would rather it went elsewhere.)

[free-llm-api-deals](https://github.com/RomeroYang/free-llm-api-deals) is a CC BY 4.0 dataset of free tiers, trial credits, limited-time offers, and price cuts across LLM API providers.

What makes it checkable rather than another list that quietly goes stale:

- every entry carries `source_url` (the provider's own page) and `verified_at`
- `deals.json` is the source of truth; the README table is generated from it, and CI fails if the two drift
- refreshed daily; expired entries are kept and marked rather than deleted, so the trail of what was once true survives

Disclosure: I maintain it, and it is published by AI Plug, an LLM API relay I run. The dataset itself is provider-neutral and reusable by anyone under CC BY 4.0.